### PR TITLE
Remove default value in tag filter when use ec2 ls command

### DIFF
--- a/cmd/ec2.go
+++ b/cmd/ec2.go
@@ -44,7 +44,7 @@ func newEC2LsCmd() *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolP("all", "a", false, "List all instances (by default, list running instances only)")
 	flags.BoolP("quiet", "q", false, "Only display InstanceIDs")
-	flags.StringP("filter-tag", "t", "Name:",
+	flags.StringP("filter-tag", "t", "",
 		"Filter instances by tag, such as \"Name:app-production\". The value of tag is assumed to be a partial match",
 	)
 	flags.StringP("fields", "F", "InstanceId InstanceType PublicIpAddress PrivateIpAddress AvailabilityZone StateName LaunchTime Tag:Name", "Output fields list separated by space")


### PR DESCRIPTION
When I create a new EC2 instance, I can't find the instance using following command:

```bash
$ myaws ec2 ls --all --profile default --region us-east-1
```

`myaws` sets `Name:` as default value of tag filter, therefore if the instance does not have `Name` tag, the application can't find this instance.

In conclusion, I removed default value in tag filter.