### PR TITLE
Allow getting 10 or more ssm parameters

### DIFF
--- a/myaws/ssm_parameter_env.go
+++ b/myaws/ssm_parameter_env.go
@@ -4,10 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/service/ssm"
-	"github.com/pkg/errors"
 )
 
 // SSMParameterEnvOptions customize the behavior of the ParameterEnv command.
@@ -28,22 +25,13 @@ func (client *Client) SSMParameterEnv(options SSMParameterEnvOptions) error {
 		names = append(names, m.Name)
 	}
 
-	input := &ssm.GetParametersInput{
-		Names:          names,
-		WithDecryption: aws.Bool(true),
-	}
-
-	response, err := client.SSM.GetParameters(input)
+	parameters, err := client.GetSSMParameters(names, true)
 	if err != nil {
-		return errors.Wrap(err, "GetParameters failed:")
-	}
-
-	if len(response.InvalidParameters) > 0 {
-		return errors.Errorf("InvalidParameters: %v", awsutil.Prettify(response.InvalidParameters))
+		return err
 	}
 
 	output := []string{}
-	for _, parameter := range response.Parameters {
+	for _, parameter := range parameters {
 		output = append(output, formatSSMParameterAsEnv(parameter, options.Name, options.DockerFormat))
 	}
 

--- a/myaws/ssm_parameter_get.go
+++ b/myaws/ssm_parameter_get.go
@@ -3,9 +3,7 @@ package myaws
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/aws/aws-sdk-go/service/ssm"
-	"github.com/pkg/errors"
 )
 
 // SSMParameterGetOptions customize the behavior of the ParameterGet command.
@@ -16,21 +14,12 @@ type SSMParameterGetOptions struct {
 
 // SSMParameterGet get values from SSM parameter store with KMS decryption.
 func (client *Client) SSMParameterGet(options SSMParameterGetOptions) error {
-	input := &ssm.GetParametersInput{
-		Names:          options.Names,
-		WithDecryption: &options.WithDecryption,
-	}
-
-	response, err := client.SSM.GetParameters(input)
+	parameters, err := client.GetSSMParameters(options.Names, options.WithDecryption)
 	if err != nil {
-		return errors.Wrap(err, "GetParameters failed:")
+		return err
 	}
 
-	if len(response.InvalidParameters) > 0 {
-		return errors.Errorf("InvalidParameters: %v", awsutil.Prettify(response.InvalidParameters))
-	}
-
-	for _, parameter := range response.Parameters {
+	for _, parameter := range parameters {
 		fmt.Fprintln(client.stdout, formatSSMParameter(parameter))
 	}
 


### PR DESCRIPTION
The AWS SSM GetPrameters API can only get 10 parameters at once.
To get 10 or more parameters, we need to call API multiple time.

https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameters.html