### PR TITLE
Enable AWS API request and response logging in debug mode

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,17 +23,17 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default $HOME/.myaws.yml)")
-	RootCmd.PersistentFlags().BoolP("debug", "", false, "Enable debug mode")
 	RootCmd.PersistentFlags().StringP("profile", "", "", "AWS profile (default none and used AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY environment variables.)")
 	RootCmd.PersistentFlags().StringP("region", "", "", "AWS region (default none and used AWS_DEFAULT_REGION environment variable.")
 	RootCmd.PersistentFlags().StringP("timezone", "", "Local", "Time zone, such as UTC, Asia/Tokyo")
 	RootCmd.PersistentFlags().BoolP("humanize", "", true, "Use Human friendly format for time")
+	RootCmd.PersistentFlags().BoolP("debug", "", false, "Enable debug mode")
 
 	viper.BindPFlag("profile", RootCmd.PersistentFlags().Lookup("profile"))
-	viper.BindPFlag("debug", RootCmd.PersistentFlags().Lookup("debug"))
 	viper.BindPFlag("region", RootCmd.PersistentFlags().Lookup("region"))
 	viper.BindPFlag("timezone", RootCmd.PersistentFlags().Lookup("timezone"))
 	viper.BindPFlag("humanize", RootCmd.PersistentFlags().Lookup("humanize"))
+	viper.BindPFlag("debug", RootCmd.PersistentFlags().Lookup("debug"))
 
 }
 
@@ -58,5 +58,6 @@ func newClient() (*myaws.Client, error) {
 		viper.GetString("region"),
 		viper.GetString("timezone"),
 		viper.GetBool("humanize"),
+		viper.GetBool("debug"),
 	)
 }

--- a/myaws/client.go
+++ b/myaws/client.go
@@ -29,6 +29,7 @@ type Client struct {
 	region      string
 	timezone    string
 	humanize    bool
+	debug       bool
 	AutoScaling *autoscaling.AutoScaling
 	EC2         *ec2.EC2
 	ECR         *ecr.ECR
@@ -40,9 +41,9 @@ type Client struct {
 }
 
 // NewClient initializes Client instance
-func NewClient(stdin io.Reader, stdout io.Writer, stderr io.Writer, profile string, region string, timezone string, humanize bool) (*Client, error) {
+func NewClient(stdin io.Reader, stdout io.Writer, stderr io.Writer, profile string, region string, timezone string, humanize bool, debug bool) (*Client, error) {
 	session := session.New()
-	config := newConfig(profile, region)
+	config := newConfig(profile, region, debug)
 	client := &Client{
 		config:      config,
 		stdin:       stdin,

--- a/myaws/config.go
+++ b/myaws/config.go
@@ -13,10 +13,22 @@ import (
 // profile, environment variables, IAM Task Role (ECS), IAM Role.
 // Unlike the aws default, load profile before environment variables
 // because we want to prioritize explicit arguments over the environment.
-func newConfig(profile string, region string) *aws.Config {
+func newConfig(profile string, region string, debug bool) *aws.Config {
 	defaultConfig := defaults.Get().Config
 	cred := newCredentials(getenv(profile, "AWS_DEFAULT_PROFILE"), getenv(region, "AWS_DEFAULT_REGION"))
-	return defaultConfig.WithCredentials(cred).WithRegion(getenv(region, "AWS_DEFAULT_REGION"))
+
+	logLevel := aws.LogLevel(aws.LogOff)
+	if debug {
+		// enable AWS API request and response logging in debug mode
+		logLevel = aws.LogLevel(aws.LogDebugWithHTTPBody | aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
+	}
+
+	config := defaultConfig.
+		WithCredentials(cred).
+		WithRegion(getenv(region, "AWS_DEFAULT_REGION")).
+		WithLogLevel(*logLevel)
+
+	return config
 }
 
 func newCredentials(profile string, region string) *credentials.Credentials {


### PR DESCRIPTION
`github.com/aws/aws-sdk-go/aws/request.Waiter` doesn't provide useful logs,
so we simply log AWS API request and response in debug mode.