### PR TITLE
ec2/ssh: Fix HostKeyCallback error

### DIFF
--- a/myaws/ec2_ssh.go
+++ b/myaws/ec2_ssh.go
@@ -104,6 +104,7 @@ func buildSSHConfig(loginName string, identityFile string) (*ssh.ClientConfig, e
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),
 		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 
 	return config, nil


### PR DESCRIPTION
Using myaws ec2 ssh returns an error.

```
unable to connect:: ssh: must specify HostKeyCallback
```

This caused by a backwards incompatible change in `x/crypto/ssh`.
A `HostKeyCallback` param is now required.

See: https://github.com/golang/go/issues/19767