### PR TITLE
ecs/node/renew: Wait until alb target healthy

### DIFF
--- a/myaws/ecs_node_renew.go
+++ b/myaws/ecs_node_renew.go
@@ -103,6 +103,18 @@ func (client *Client) ECSNodeRenew(options ECSNodeRenewOptions) error {
 		return err
 	}
 
+	// A stable state for all services does not mean that all targets are healthy.
+	// We need to explicitly confirm it.
+	fmt.Fprintln(client.stdout, "Wait until all targets healthy...")
+	client.WaitUntilECSAllTargetsInService(options.Cluster)
+	if err != nil {
+		return err
+	}
+
+	if err = client.printECSStatus(options.Cluster); err != nil {
+		return err
+	}
+
 	// restore the desired capacity and wait until old instances are discarded
 	fmt.Fprintf(client.stdout, "Update autoscaling group %s (DesiredCapacity: %d => %d)\n", options.AsgName, targetCapacity, desiredCapacity)
 

--- a/myaws/ecs_node_renew.go
+++ b/myaws/ecs_node_renew.go
@@ -94,7 +94,7 @@ func (client *Client) ECSNodeRenew(options ECSNodeRenewOptions) error {
 	// It depends on the deployment strategy of each service.
 	// We should make sure all services are stable
 	fmt.Fprintln(client.stdout, "Wait until all ECS services stable...")
-	client.WaitUntilECSAllServicesStable(options.Cluster)
+	err = client.WaitUntilECSAllServicesStable(options.Cluster)
 	if err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func (client *Client) ECSNodeRenew(options ECSNodeRenewOptions) error {
 	// A stable state for all services does not mean that all targets are healthy.
 	// We need to explicitly confirm it.
 	fmt.Fprintln(client.stdout, "Wait until all targets healthy...")
-	client.WaitUntilECSAllTargetsInService(options.Cluster)
+	err = client.WaitUntilECSAllTargetsInService(options.Cluster)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I found that a stable state for all ECS services does not mean that all targets are healthy.
We need to explicitly confirm it.