### PR TITLE
Add ineffassign to detect unchecked errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ GOBIN := $(shell echo "$${GOPATH%%:*}/bin")
 endif
 
 GOLINT := $(GOBIN)/golint
+INEFFASSIGN := $(GOBIN)/ineffassign
 GORELEASER := $(GOBIN)/goreleaser
 
 $(GOLINT): ; @go install github.com/golang/lint/golint
+$(INEFFASSIGN): ; @go install github.com/gordonklaus/ineffassign
 $(GORELEASER): ; @go install github.com/goreleaser/goreleaser
 
 .DEFAULT_GOAL := build
@@ -32,6 +34,10 @@ release: $(GORELEASER)
 lint: $(GOLINT)
 	@golint ./...
 
+.PHONY: ineffassign
+ineffassign: $(INEFFASSIGN)
+	@ineffassign ./
+
 .PHONY: vet
 vet:
 	@go vet ./...
@@ -41,4 +47,4 @@ test:
 	@go test ./...
 
 .PHONY: check
-check: lint vet test build
+check: lint ineffassign vet test build

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.25.16
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/lint v0.0.0-20190301231843-5614ed5bae6f
+	github.com/gordonklaus/ineffassign v0.0.0-20190601041439-ed7b1b5ee0f8
 	github.com/goreleaser/goreleaser v0.102.0
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4r
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/gordonklaus/ineffassign v0.0.0-20190601041439-ed7b1b5ee0f8 h1:ehVe1P3MbhHjeN/Rn66N2fGLrP85XXO1uxpLhv0jtX8=
+github.com/gordonklaus/ineffassign v0.0.0-20190601041439-ed7b1b5ee0f8/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/goreleaser/goreleaser v0.102.0 h1:U1AA7okfNLZG1R7T84qnNKbADFLPKBjVkP05+fWvihI=
 github.com/goreleaser/goreleaser v0.102.0/go.mod h1:gFykrGsDXTNvcYSMQH4lEpcxXHyE+7jSjf3hakwnBPQ=
 github.com/goreleaser/nfpm v0.9.7 h1:h8RQMDztu6cW7b0/s4PGbdeMYykAbJG0UMXaWG5uBMI=

--- a/myaws/ecs.go
+++ b/myaws/ecs.go
@@ -29,6 +29,9 @@ func (client *Client) findECSNodes(cluster string) ([]*ecs.ContainerInstance, er
 			ContainerInstances: arns.ContainerInstanceArns,
 		},
 	)
+	if err != nil {
+		return nil, errors.Wrapf(err, "DescribeContainerInstances failed")
+	}
 
 	if len(instances.ContainerInstances) == 0 {
 		return nil, errors.New("ListContainerInstances succeed, but DescribeContainerInstances returns no instances")

--- a/tools.go
+++ b/tools.go
@@ -3,6 +3,7 @@
 package tools
 
 import (
-	_ "github.com/golang/lint/golint"    // executable dependency for development
-	_ "github.com/goreleaser/goreleaser" // executable dependency for development
+	_ "github.com/golang/lint/golint"      // executable dependency for development
+	_ "github.com/gordonklaus/ineffassign" // executable dependency for development
+	_ "github.com/goreleaser/goreleaser"   // executable dependency for development
 )


### PR DESCRIPTION
The following was a bug fix for error handling at ecs node drain:
#25

But it should be checked by static analysis.
The `errcheck` cannot detect it, but `ineffassign` can. So we add `ineffassign` to `make check`.

I also fixed unchecked error in findECSNodes() found by ineffassign