### PR TITLE
fix termintate unintended instance on `ecs node renew`

### DIFF
--- a/myaws/autoscaling_set_instance_protection.go
+++ b/myaws/autoscaling_set_instance_protection.go
@@ -15,14 +15,14 @@ type AutoScalingSetInstanceProtectionOptions struct {
 // AutoScalingSetInstanceProtection protects from termination when scale in your autoscaling group.
 func (client *Client) AutoScalingSetInstanceProtection(options AutoScalingSetInstanceProtectionOptions) error {
 	if len(options.InstanceIds) > 0 {
-		if err := client.AutoScalingSetInstanceProtectionInstances(options.AsgName, options.InstanceIds, options.ProtectedFromScaleIn); err != nil {
+		if err := client.autoScalingSetInstanceProtectionInstances(options.AsgName, options.InstanceIds, options.ProtectedFromScaleIn); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (client *Client) AutoScalingSetInstanceProtectionInstances(asgName string, instanceIds []*string, protectedFromScaleIn bool) error {
+func (client *Client) autoScalingSetInstanceProtectionInstances(asgName string, instanceIds []*string, protectedFromScaleIn bool) error {
 	params := &autoscaling.SetInstanceProtectionInput{
 		AutoScalingGroupName: &asgName,
 		InstanceIds:          instanceIds,

--- a/myaws/autoscaling_set_instance_protection.go
+++ b/myaws/autoscaling_set_instance_protection.go
@@ -1,0 +1,37 @@
+package myaws
+
+import (
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/pkg/errors"
+)
+
+// AutoScalingSetInstanceProtectionOptions customize the behavior of the Attach command.
+type AutoScalingSetInstanceProtectionOptions struct {
+	AsgName              string
+	InstanceIds          []*string
+	ProtectedFromScaleIn bool
+}
+
+// AutoScalingSetInstanceProtection protects from termination when scale in your autoscaling group.
+func (client *Client) AutoScalingSetInstanceProtection(options AutoScalingSetInstanceProtectionOptions) error {
+	if len(options.InstanceIds) > 0 {
+		if err := client.AutoScalingSetInstanceProtectionInstances(options.AsgName, options.InstanceIds, options.ProtectedFromScaleIn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (client *Client) AutoScalingSetInstanceProtectionInstances(asgName string, instanceIds []*string, protectedFromScaleIn bool) error {
+	params := &autoscaling.SetInstanceProtectionInput{
+		AutoScalingGroupName: &asgName,
+		InstanceIds:          instanceIds,
+		ProtectedFromScaleIn: &protectedFromScaleIn,
+	}
+
+	if _, err := client.AutoScaling.SetInstanceProtection(params); err != nil {
+		return errors.Wrap(err, "SetInstanceProtection failed:")
+	}
+
+	return nil
+}

--- a/myaws/autoscaling_set_instance_protection.go
+++ b/myaws/autoscaling_set_instance_protection.go
@@ -5,7 +5,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// AutoScalingSetInstanceProtectionOptions customize the behavior of the Attach command.
+// AutoScalingSetInstanceProtectionOptions customizes the behavior of the Attach command.
 type AutoScalingSetInstanceProtectionOptions struct {
 	AsgName              string
 	InstanceIds          []*string

--- a/myaws/ecs_node_renew.go
+++ b/myaws/ecs_node_renew.go
@@ -128,6 +128,12 @@ func (client *Client) ECSNodeRenew(options ECSNodeRenewOptions) error {
 		return err
 	}
 
+	// Enable scale in protection for specific instances before scaling in.
+	// In the default termination policy of auto scaling, instances close to the next billing time will terminate when the launch configuration is the same.
+	// By running this function, your auto scaling group scales out, then scales in.
+	// During scale in, instances created during scale out may be subject to termination.
+	// To prevent this, set scale in protection for instances created at scale out.
+	// https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html
 	fmt.Fprintln(client.stdout, "Setting scale in protection: ", awsutil.Prettify(protectInstanceIds))
 	// set "scale in protection" to instances created at scale-out.
 	err = client.AutoScalingSetInstanceProtection(AutoScalingSetInstanceProtectionOptions{

--- a/myaws/ecs_node_renew.go
+++ b/myaws/ecs_node_renew.go
@@ -139,7 +139,7 @@ func (client *Client) ECSNodeRenew(options ECSNodeRenewOptions) error {
 
 	// Select instances to protect from scale in.
 	// By setting "scale-in protection" to instances created at scale-out,
-	// the intended instances (instances created before scale-in) is only terminated at scale-in process.
+	// the intended instances (instances created before scale-in) are only terminated at scale-in process.
 	protectInstanceIds, err := client.selectInstanceToProtectFromScaleIn(oldInstanceIds, allInstanceIds)
 	if err != nil {
 		return err

--- a/myaws/ecs_node_renew.go
+++ b/myaws/ecs_node_renew.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/pkg/errors"
 )
 
@@ -118,6 +119,42 @@ func (client *Client) ECSNodeRenew(options ECSNodeRenewOptions) error {
 		return err
 	}
 
+	// Get a list of instance IDs before auto scaling
+	var oldInstanceIds []*string
+	for _, oldNode := range oldNodes {
+		oldInstanceIds = append(oldInstanceIds, oldNode.Ec2InstanceId)
+	}
+
+	// Get a list of instances after auto scaling
+	allNodes, err := client.findECSNodes(options.Cluster)
+	if err != nil {
+		return err
+	}
+
+	// Get a list of instance IDs after auto scaling
+	var allInstanceIds []*string
+	for _, allNode := range allNodes {
+		allInstanceIds = append(allInstanceIds, allNode.Ec2InstanceId)
+	}
+
+	// Select instances to protect from scale in.
+	// By setting "scale-in protection" to instances created at scale-out,
+	// the intended instances (instances created before scale-in) is only terminated at scale-in process.
+	protectInstanceIds, err := client.selectInstanceToProtectFromScaleIn(oldInstanceIds, allInstanceIds)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(client.stdout, "Setting scale in protection: ", awsutil.Prettify(protectInstanceIds))
+	// set "scale in protection" to instances created at scale-out.
+	err = client.AutoScalingSetInstanceProtection(AutoScalingSetInstanceProtectionOptions{
+		options.AsgName,
+		protectInstanceIds,
+		true})
+	if err != nil {
+		return err
+	}
+
 	// restore the desired capacity and wait until old instances are discarded
 	fmt.Fprintf(client.stdout, "Update autoscaling group %s (DesiredCapacity: %d => %d)\n", options.AsgName, targetCapacity, desiredCapacity)
 
@@ -130,10 +167,60 @@ func (client *Client) ECSNodeRenew(options ECSNodeRenewOptions) error {
 		return err
 	}
 
+	// remove "scale in protection" to instances created at scale-out.
+	fmt.Fprintln(client.stdout, "Removing scale in protection: ", awsutil.Prettify(protectInstanceIds))
+	err = client.AutoScalingSetInstanceProtection(AutoScalingSetInstanceProtectionOptions{
+		options.AsgName,
+		protectInstanceIds,
+		false})
+	if err != nil {
+		return err
+	}
+
 	if err = client.printECSStatus(options.Cluster); err != nil {
 		return err
 	}
 
 	fmt.Fprintln(client.stdout, "end: ecs node renew")
 	return nil
+}
+
+// selectInstanceToProtectFromScaleIn selects instance to protect from Scale in.
+// instance select rule:
+//   instances after scale out - instances before scale out - instances which already set `InstanceProtection==true`
+func (client *Client) selectInstanceToProtectFromScaleIn(oldInstanceIds, allInstanceIds []*string) ([]*string, error) {
+	// get newly created nodes (allInstanceIds - oldInstanceIds)
+	newInstanceIds := difference(allInstanceIds, oldInstanceIds)
+
+	// exclude ProtectedFromScaleIn == true nodes
+	params := &autoscaling.DescribeAutoScalingInstancesInput{
+		InstanceIds: newInstanceIds,
+	}
+	response, err := client.AutoScaling.DescribeAutoScalingInstances(params)
+	if err != nil {
+		return nil, errors.Wrap(err, "DescribeAutoScalingGroups failed:")
+	}
+
+	var targetInstanceIds []*string
+	for _, instance := range response.AutoScalingInstances {
+		if *instance.ProtectedFromScaleIn == false {
+			targetInstanceIds = append(targetInstanceIds, instance.InstanceId)
+		}
+	}
+	return targetInstanceIds, nil
+}
+
+// difference returns the elements in `a` that aren't in `b`.
+func difference(a, b []*string) []*string {
+	mb := make(map[string]struct{}, len(b))
+	for _, x := range b {
+		mb[*x] = struct{}{}
+	}
+	var diff []*string
+	for _, x := range a {
+		if _, found := mb[*x]; !found {
+			diff = append(diff, x)
+		}
+	}
+	return diff
 }

--- a/myaws/ecs_node_renew.go
+++ b/myaws/ecs_node_renew.go
@@ -218,7 +218,7 @@ func difference(a, b []*string) []*string {
 	}
 	var diff []*string
 	for _, x := range a {
-		if _, found := mb[*x]; !found {
+		if _, ok := mb[*x]; !ok {
 			diff = append(diff, x)
 		}
 	}


### PR DESCRIPTION
fixed https://github.com/minamijoyo/myaws/issues/28

In `myaws ecs node renew` command,

- set "scale-in protection" option for instances created at scale-out
- remove "scale-in protection" at scale-in

If "scale-in protection" is already set  in ASG settings, "scale-in protection" is not deleted at scale-in.