### PR TITLE
use GetParametersByPath instead of GetParameters when path started with slash on SSMParameterEnv

### DIFF
--- a/myaws/ssm_parameter.go
+++ b/myaws/ssm_parameter.go
@@ -92,7 +92,7 @@ func (client *Client) getSSMParametersPerChunk(names []*string, withDecryption b
 	return response.Parameters, nil
 }
 
-// GetParametersByPath returns an array of parameters parameters at once
+// GetParametersByPath returns a list of parameters that start with the specified path.
 func (client *Client) GetParametersByPath(path *string, withDecryption bool) ([]*ssm.Parameter, error) {
 	input := &ssm.GetParametersByPathInput{
 		Path:           path,

--- a/myaws/ssm_parameter.go
+++ b/myaws/ssm_parameter.go
@@ -107,7 +107,7 @@ func (client *Client) GetParametersByPath(path *string, withDecryption bool) ([]
 			return true
 		})
 	if err != nil {
-		return nil, errors.Wrap(err, "GetParameters failed:")
+		return nil, errors.Wrap(err, "GetParametersByPath failed:")
 	}
 	return parameters, nil
 }

--- a/myaws/ssm_parameter.go
+++ b/myaws/ssm_parameter.go
@@ -92,6 +92,7 @@ func (client *Client) getSSMParametersPerChunk(names []*string, withDecryption b
 	return response.Parameters, nil
 }
 
+// GetParametersByPath returns an array of parameters parameters at once
 func (client *Client) GetParametersByPath(path *string, withDecryption bool) ([]*ssm.Parameter, error) {
 	input := &ssm.GetParametersByPathInput{
 		Path:           path,

--- a/myaws/ssm_parameter.go
+++ b/myaws/ssm_parameter.go
@@ -91,3 +91,22 @@ func (client *Client) getSSMParametersPerChunk(names []*string, withDecryption b
 
 	return response.Parameters, nil
 }
+
+func (client *Client) GetParametersByPath(path *string, withDecryption bool) ([]*ssm.Parameter, error) {
+	input := &ssm.GetParametersByPathInput{
+		Path:           path,
+		Recursive:      aws.Bool(true),
+		WithDecryption: aws.Bool(withDecryption),
+	}
+
+	var parameters []*ssm.Parameter
+	err := client.SSM.GetParametersByPathPages(input,
+		func(page *ssm.GetParametersByPathOutput, lastPage bool) bool {
+			parameters = append(parameters, page.Parameters...)
+			return true
+		})
+	if err != nil {
+		return nil, errors.Wrap(err, "GetParameters failed:")
+	}
+	return parameters, nil
+}

--- a/myaws/ssm_parameter_env.go
+++ b/myaws/ssm_parameter_env.go
@@ -63,10 +63,10 @@ func formatSSMParameterAsEnv(parameter *ssm.Parameter, prefix string, dockerForm
 		suffix = suffix[1:]
 	}
 	// Flatten period and slash to underscore for nested keys.
-	flatten := strings.Replace(suffix, ".", "_", -1)
-	flatten = strings.Replace(flatten, "/", "_", -1)
+	flattenDot := strings.Replace(suffix, ".", "_", -1)
+	flattenSlash := strings.Replace(flattenDot, "/", "_", -1)
 	// The name of environment variable should be uppercase.
-	name := strings.ToUpper(flatten)
+	name := strings.ToUpper(flattenSlash)
 	outputOptionName := ""
 
 	if dockerFormat {

--- a/myaws/ssm_parameter_env.go
+++ b/myaws/ssm_parameter_env.go
@@ -16,6 +16,14 @@ type SSMParameterEnvOptions struct {
 // SSMParameterEnv prints SSM parameters as a list of environment variables.
 func (client *Client) SSMParameterEnv(options SSMParameterEnvOptions) error {
 	var parameters []*ssm.Parameter
+	// Since GetSSMParameters does not have a hierarchy, it is necessary to retrieve all keys at first, then filter the target keys.
+	// Use the DescribeParameters API when retrieving the list of keys.
+	// The rate limit of the DescribeParameters API is not publicly available.
+	// When your SSM Parameter store have large number of keys, it is possible to exceed the rate limit.
+	// https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DescribeParameters.html
+	// The GetParametersByPath API has a hierarchy separated by '/'.
+	// This API has less impact to the rate limit.
+	// https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParametersByPath.html
 	if strings.HasPrefix(options.Name, "/") {
 		var err error
 		parameters, err = client.GetParametersByPath(&options.Name, true)

--- a/myaws/ssm_parameter_env.go
+++ b/myaws/ssm_parameter_env.go
@@ -59,7 +59,7 @@ func formatSSMParameterAsEnv(parameter *ssm.Parameter, prefix string, dockerForm
 	// Drop prefix and get suffix as a key name.
 	suffix := strings.Replace(*parameter.Name, prefix, "", 1)
 	// if first character is period, then drop it.
-	if suffix[0] == '.'|'/' {
+	if suffix[0] == '.' || suffix[0] == '/' {
 		suffix = suffix[1:]
 	}
 	// Flatten period and slash to underscore for nested keys.

--- a/myaws/ssm_parameter_env.go
+++ b/myaws/ssm_parameter_env.go
@@ -51,11 +51,12 @@ func formatSSMParameterAsEnv(parameter *ssm.Parameter, prefix string, dockerForm
 	// Drop prefix and get suffix as a key name.
 	suffix := strings.Replace(*parameter.Name, prefix, "", 1)
 	// if first character is period, then drop it.
-	if suffix[0] == '.' {
+	if suffix[0] == '.'|'/' {
 		suffix = suffix[1:]
 	}
-	// Flatten period to underscore for nested keys.
+	// Flatten period and slash to underscore for nested keys.
 	flatten := strings.Replace(suffix, ".", "_", -1)
+	flatten = strings.Replace(flatten, "/", "_", -1)
 	// The name of environment variable should be uppercase.
 	name := strings.ToUpper(flatten)
 	outputOptionName := ""


### PR DESCRIPTION
There are two APIs to get the value of SSM Parameter Store: GetParameters and GetParametersByPath.

GetParameters: 
- Rate Limit is undocumented.
- It retrieves all values


GetParametersByPath
- Rate Limit is documented.
- We can specify level, and it recieves only values that have specified level.

This PR can use  GetParametersByPath API when running `myaws ssm parameter env` with name starts with slash.

As a result, even if there are many keys stored in SSM Parameter Store, the values can be obtained without being limited by Rate Limit.