### PR TITLE
add registry-ids (-r) option to ECR get-login

### DIFF
--- a/cmd/ecr.go
+++ b/cmd/ecr.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/minamijoyo/myaws/myaws"
 )
 
 func init() {
@@ -32,6 +35,11 @@ func newECRGetLoginCmd() *cobra.Command {
 		RunE:  runECRGetLoginCmd,
 	}
 
+	flags := cmd.Flags()
+	flags.StringP("registry-ids", "r", "", "Amazon ECR registries ID")
+
+	viper.BindPFlag("ecr.parameter.get-login.registry-ids", flags.Lookup("registry-ids"))
+
 	return cmd
 }
 
@@ -41,5 +49,9 @@ func runECRGetLoginCmd(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "newClient failed:")
 	}
 
-	return client.ECRGetLogin()
+	options := myaws.ECRGetLoginOptions{
+		RegistryIds: viper.GetString("ecr.parameter.get-login.registry-ids"),
+	}
+
+	return client.ECRGetLogin(options)
 }

--- a/myaws/ecr_get_login.go
+++ b/myaws/ecr_get_login.go
@@ -5,13 +5,23 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/pkg/errors"
 )
 
+// ECRGetLoginOptions customize the behavior of the ECRGetLogin command.
+type ECRGetLoginOptions struct {
+	RegistryIds string
+}
+
 // ECRGetLogin gets docker login command with authorization token for ECR.
-func (client *Client) ECRGetLogin() error {
-	params := &ecr.GetAuthorizationTokenInput{}
+func (client *Client) ECRGetLogin(options ECRGetLoginOptions) error {
+	params := &ecr.GetAuthorizationTokenInput{
+	    RegistryIds: []*string{
+	        aws.String(options.RegistryIds),
+	    },
+	}
 
 	response, err := client.ECR.GetAuthorizationToken(params)
 	if err != nil {


### PR DESCRIPTION
When using multiple AWS accounts, if you want to reference the ECR repository from another account, we added an option so that you can specify registry-ids because you can not log in

`myaws ecr get-login -r <registryIds>`