### PR TITLE
ecs/status: Print Header

### DIFF
--- a/cmd/ecs.go
+++ b/cmd/ecs.go
@@ -84,6 +84,11 @@ func newECSNodeLsCmd() *cobra.Command {
 		RunE:  runECSNodeLsCmd,
 	}
 
+	flags := cmd.Flags()
+	flags.BoolP("print-header", "H", false, "Print Header")
+
+	viper.BindPFlag("ecs.node.ls.print-header", flags.Lookup("print-header"))
+
 	return cmd
 }
 
@@ -98,7 +103,8 @@ func runECSNodeLsCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	options := myaws.ECSNodeLsOptions{
-		Cluster: args[0],
+		Cluster:     args[0],
+		PrintHeader: viper.GetBool("ecs.node.ls.print-header"),
 	}
 	return client.ECSNodeLs(options)
 }
@@ -251,6 +257,11 @@ func newECSServiceLsCmd() *cobra.Command {
 		RunE:  runECSServiceLsCmd,
 	}
 
+	flags := cmd.Flags()
+	flags.BoolP("print-header", "H", false, "Print Header")
+
+	viper.BindPFlag("ecs.service.ls.print-header", flags.Lookup("print-header"))
+
 	return cmd
 }
 
@@ -265,7 +276,8 @@ func runECSServiceLsCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	options := myaws.ECSServiceLsOptions{
-		Cluster: args[0],
+		Cluster:     args[0],
+		PrintHeader: viper.GetBool("ecs.service.ls.print-header"),
 	}
 	return client.ECSServiceLs(options)
 }

--- a/myaws/ecs.go
+++ b/myaws/ecs.go
@@ -88,7 +88,8 @@ func (client *Client) findECSServices(cluster string) ([]*ecs.Service, error) {
 func (client *Client) printECSStatus(cluster string) error {
 	fmt.Fprintln(client.stdout, "[Service]")
 	err := client.ECSServiceLs(ECSServiceLsOptions{
-		Cluster: cluster,
+		Cluster:     cluster,
+		PrintHeader: true,
 	})
 	if err != nil {
 		return err
@@ -96,7 +97,8 @@ func (client *Client) printECSStatus(cluster string) error {
 
 	fmt.Fprintln(client.stdout, "[Node]")
 	err = client.ECSNodeLs(ECSNodeLsOptions{
-		Cluster: cluster,
+		Cluster:     cluster,
+		PrintHeader: true,
 	})
 	if err != nil {
 		return err

--- a/myaws/ecs_node_ls.go
+++ b/myaws/ecs_node_ls.go
@@ -21,8 +21,8 @@ func (client *Client) ECSNodeLs(options ECSNodeLsOptions) error {
 	}
 
 	if options.PrintHeader {
-		header := fmt.Sprintf("%s\t%s\t%-10s\t%s\t%s\t%s",
-			"Namespace",
+		header := fmt.Sprintf("%-32s\t%-19s\t%-10s\t%s\t%s\t%s",
+			"ContainerInstanceId",
 			"Ec2InstanceId",
 			"Status",
 			"Running",
@@ -41,12 +41,11 @@ func (client *Client) ECSNodeLs(options ECSNodeLsOptions) error {
 
 func formatECSNode(client *Client, instance *ecs.ContainerInstance) string {
 	arn := strings.Split(*instance.ContainerInstanceArn, "/")
-
 	// To fix misalignment, we use the width of state is 10 characters here,
 	// because 8 characters + 2 characters as future margin of change.
 	// The valid values of status are ACTIVE, INACTIVE, or DRAINING.
 	return fmt.Sprintf("%s\t%s\t%-10s\t%d\t%d\t%s",
-		arn[1],
+		arn[2],
 		*instance.Ec2InstanceId,
 		*instance.Status,
 		*instance.RunningTasksCount,

--- a/myaws/ecs_node_ls.go
+++ b/myaws/ecs_node_ls.go
@@ -9,7 +9,8 @@ import (
 
 // ECSNodeLsOptions customize the behavior of the Ls command.
 type ECSNodeLsOptions struct {
-	Cluster string
+	Cluster     string
+	PrintHeader bool
 }
 
 // ECSNodeLs describes ECS container instances.
@@ -17,6 +18,18 @@ func (client *Client) ECSNodeLs(options ECSNodeLsOptions) error {
 	instances, err := client.findECSNodes(options.Cluster)
 	if err != nil {
 		return err
+	}
+
+	if options.PrintHeader {
+		header := fmt.Sprintf("%s\t%s\t%-10s\t%s\t%s\t%s",
+			"Namespace",
+			"Ec2InstanceId",
+			"Status",
+			"Running",
+			"Pending",
+			"RegisteredAt",
+		)
+		fmt.Fprintln(client.stdout, header)
 	}
 
 	for _, instance := range instances {

--- a/myaws/ecs_service_ls.go
+++ b/myaws/ecs_service_ls.go
@@ -9,7 +9,8 @@ import (
 
 // ECSServiceLsOptions customize the behavior of the Ls command.
 type ECSServiceLsOptions struct {
-	Cluster string
+	Cluster     string
+	PrintHeader bool
 }
 
 // ECSServiceLs describes ECS services.
@@ -17,6 +18,18 @@ func (client *Client) ECSServiceLs(options ECSServiceLsOptions) error {
 	services, err := client.findECSServices(options.Cluster)
 	if err != nil {
 		return err
+	}
+
+	if options.PrintHeader {
+		header := fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s",
+			"Desired",
+			"Running",
+			"Pending",
+			"Deploy",
+			"Service",
+			"TaskDefinition",
+		)
+		fmt.Fprintln(client.stdout, header)
 	}
 
 	for _, service := range services {

--- a/myaws/ecs_service_ls.go
+++ b/myaws/ecs_service_ls.go
@@ -21,7 +21,7 @@ func (client *Client) ECSServiceLs(options ECSServiceLsOptions) error {
 	}
 
 	if options.PrintHeader {
-		header := fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s",
+		header := fmt.Sprintf("%s\t%s\t%s\t%s\t%-32s\t%s",
 			"Desired",
 			"Running",
 			"Pending",
@@ -42,7 +42,7 @@ func (client *Client) ECSServiceLs(options ECSServiceLsOptions) error {
 func formatECSService(client *Client, options ECSServiceLsOptions, service *ecs.Service) string {
 	taskDefinitions := strings.Split(*service.TaskDefinition, "/")
 
-	return fmt.Sprintf("%d\t%d\t%d\t%d\t%s\t%s",
+	return fmt.Sprintf("%d\t%d\t%d\t%d\t%-32s\t%s",
 		*service.DesiredCount,
 		*service.RunningCount,
 		*service.PendingCount,


### PR DESCRIPTION
The current outputs is a bit ambiguous.
We want to add a header to outputs of `ecs status` command.
So we add `--print-header` option to `ecs node ls` and `ecs service ls`. 
`* ls` commands may use with `wc -l`, so its option default to false.

While adjusting outputs, I found a namespace of container instance is redundant (it seems to be always cluster name) and container instance id is missing which needs drain operation.
So we change outputs of `ecs node ls`. This is a breaking change.
