### PR TITLE
Extends wait timeout for ecs service stable

### DIFF
--- a/cmd/ecs.go
+++ b/cmd/ecs.go
@@ -206,7 +206,12 @@ func newECSNodeRenewCmd() *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringP("asg-name", "a", "", "A name of AutoScalingGroup to which the ECS container instances belong")
 
+	// Note that this is a total timeout, and indivisual wait operations can
+	// timeout in shorter amount of time.
+	flags.Int64P("timeout", "t", 3600, "Number of secconds to wait before timeout")
+
 	viper.BindPFlag("ecs.node.renew.asg-name", flags.Lookup("asg-name"))
+	viper.BindPFlag("ecs.node.renew.timeout", flags.Lookup("timeout"))
 
 	return cmd
 }
@@ -225,9 +230,13 @@ func runECSNodeRenewCmd(cmd *cobra.Command, args []string) error {
 	if len(asgName) == 0 {
 		return errors.New("asg-name is required")
 	}
+
+	timeout := time.Duration(viper.GetInt64("ecs.node.renew.timeout")) * time.Second
+
 	options := myaws.ECSNodeRenewOptions{
 		Cluster: args[0],
 		AsgName: asgName,
+		Timeout: timeout,
 	}
 
 	return client.ECSNodeRenew(options)

--- a/myaws/ecs_service_update.go
+++ b/myaws/ecs_service_update.go
@@ -37,15 +37,9 @@ func (client *Client) ECSServiceUpdate(options ECSServiceUpdateOptions) error {
 		fmt.Fprintln(client.stdout, "Wait until the service stable...")
 		ctx, cancel := context.WithTimeout(context.Background(), options.Timeout)
 		defer cancel()
-
-		err = client.ECS.WaitUntilServicesStableWithContext(
-			ctx,
-			&ecs.DescribeServicesInput{
-				Cluster:  &options.Cluster,
-				Services: []*string{&options.Service},
-			})
+		err = client.WaitUntilECSServicesStableWithContext(ctx, options.Cluster, []string{options.Service})
 		if err != nil {
-			return errors.Wrapf(err, "WaitUntilServicesStable failed")
+			return err
 		}
 	}
 


### PR DESCRIPTION
The official (*ECS) WaitUntilServicesStableWithContext has fixed MaxAttempts(40) and Delay(15),
this means we can't wait more than 10 minutes even if we pass the context.
So we wrap it and allow timeout with a given context.

I found it in `ecs service update`, but it also affects `ecs node renew`, so I fixed them.