### PR TITLE
ecs/node/drain: Allow to set timeout with a given context

### DIFF
--- a/cmd/ecs.go
+++ b/cmd/ecs.go
@@ -165,9 +165,11 @@ func newECSNodeDrainCmd() *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringP("container-instances", "i", "", "A list of container instance IDs or full ARN entries separated by space")
 	flags.BoolP("wait", "w", false, "Wait until container instances are drained")
+	flags.Int64P("timeout", "t", 600, "Number of secconds to wait before timeout")
 
 	viper.BindPFlag("ecs.node.drain.container-instances", flags.Lookup("container-instances"))
 	viper.BindPFlag("ecs.node.drain.wait", flags.Lookup("wait"))
+	viper.BindPFlag("ecs.node.drain.timeout", flags.Lookup("timeout"))
 
 	return cmd
 }
@@ -187,10 +189,13 @@ func runECSNodeDrainCmd(cmd *cobra.Command, args []string) error {
 		return errors.New("container-instances is required")
 	}
 
+	timeout := time.Duration(viper.GetInt64("ecs.node.drain.timeout")) * time.Second
+
 	options := myaws.ECSNodeDrainOptions{
 		Cluster:            args[0],
 		ContainerInstances: containerInstances,
 		Wait:               viper.GetBool("ecs.node.drain.wait"),
+		Timeout:            timeout,
 	}
 
 	return client.ECSNodeDrain(options)

--- a/myaws/ecs_node_renew.go
+++ b/myaws/ecs_node_renew.go
@@ -111,10 +111,11 @@ func (client *Client) ecsNodeRenewWithContext(ctx context.Context, options ECSNo
 		oldNodeArns = append(oldNodeArns, oldNode.ContainerInstanceArn)
 	}
 	fmt.Fprintf(client.stdout, "Drain old container instances and wait until no task running...\n%v\n", awsutil.Prettify(oldNodeArns))
-	err = client.ECSNodeDrain(ECSNodeDrainOptions{
+	err = client.ecsNodeDrainWithContext(ctx, ECSNodeDrainOptions{
 		Cluster:            options.Cluster,
 		ContainerInstances: oldNodeArns,
 		Wait:               true,
+		Timeout:            options.Timeout,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
If we have a lot of containers on host, `ecs node renew` fails with a timeout in node drain phase. We should pass a context explicitly and timeout with the given context. We also add timeout flag to `ecs node drain` for consistency.