### PR TITLE
ecs/service/update: Fetch the latest task definition on force

### DIFF
--- a/cmd/ecs.go
+++ b/cmd/ecs.go
@@ -298,7 +298,7 @@ func runECSServiceLsCmd(cmd *cobra.Command, args []string) error {
 
 func newECSServiceUpdateCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update CLUSTER SERVICE",
+		Use:   "update CLUSTER",
 		Short: "Update ECS services",
 		RunE:  runECSServiceUpdateCmd,
 	}

--- a/myaws/ecs_service_update.go
+++ b/myaws/ecs_service_update.go
@@ -3,6 +3,7 @@ package myaws
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -28,6 +29,24 @@ func (client *Client) ECSServiceUpdate(options ECSServiceUpdateOptions) error {
 		ForceNewDeployment: &options.Force,
 	}
 
+	if options.Force {
+		// When updating a ECS task definition, We want to deploy a new task with
+		// new revision.
+		// The ECS UpdateService API doesn't update the revision without the
+		// TaskDefinition parameter. To update the revision, we set only a task
+		// family without revision. If a revision is not specified, the latest
+		// ACTIVE revision is used. If the current task uses the latest ACTIVE one,
+		// it hasn't no side-effect.
+		// Since the Force option expects to deploy and converge to the latest
+		// state, when Force option is enabled, we implicitly fetch and set the
+		// task family.
+		family, err := client.getECSTaskDefinitionFamily(options.Cluster, options.Service)
+		if err != nil {
+			return err
+		}
+		input.TaskDefinition = &family
+	}
+
 	_, err := client.ECS.UpdateService(input)
 	if err != nil {
 		return errors.Wrapf(err, "UpdateService failed")
@@ -44,4 +63,33 @@ func (client *Client) ECSServiceUpdate(options ECSServiceUpdateOptions) error {
 	}
 
 	return nil
+}
+
+// getECSTaskDefinitionFamily returns a family name of ECS task definition used by a given ECS service.
+func (client *Client) getECSTaskDefinitionFamily(cluster string, service string) (string, error) {
+	input := &ecs.DescribeServicesInput{
+		Cluster:  &cluster,
+		Services: []*string{&service},
+	}
+
+	resp, err := client.ECS.DescribeServices(input)
+	if err != nil {
+		return "", errors.Wrapf(err, "DescribeServices failed")
+	}
+
+	if len(resp.Services) == 0 {
+		return "", fmt.Errorf("service not fould: cluster = %s, service = %s", cluster, service)
+	}
+
+	arn := *resp.Services[0].TaskDefinition
+
+	// arn:aws:ecs:<region>:<account-id>:task-definition/<family>:<revison>
+	re := regexp.MustCompile(`^arn:aws:ecs:.+:.+:task-definition/(.+):.+$`)
+	matched := re.FindStringSubmatch(arn)
+	if len(matched) != 2 || len(matched[1]) == 0 {
+		return "", fmt.Errorf("failed to parse task definition arn: %s", arn)
+	}
+	family := matched[1]
+
+	return family, nil
 }


### PR DESCRIPTION
When updating a ECS task definition, We want to deploy a new task with new revision.

The ECS UpdateService API doesn't update the revision without the TaskDefinition parameter.
To update the revision, we set only a task family without revision.
If a revision is not specified, the latest ACTIVE revision is used.
If the current task uses the latest ACTIVE one, it hasn't no side-effect.

Since the Force option expects to deploy and converge to the latest state,
when Force option is enabled, we implicitly fetch and set the task family.