### PR TITLE
Set a version number explicitly in source

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - "-s -w -X github.com/minamijoyo/myaws/cmd.Version={{.Version}} -X github.com/minamijoyo/myaws/cmd.Revision={{.ShortCommit}}"
+      - "-s -w"
 archive:
   name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
   files:

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,12 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	// Version is version number which automatically set on build.
-	Version string
-	// Revision is git commit hash which automatically set `git rev-parse --short HEAD` on build.
-	Revision string
-)
+// version is a version number.
+var version = "0.4.0-dev"
 
 func init() {
 	RootCmd.AddCommand(newVersionCmd())
@@ -22,7 +18,7 @@ func newVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print version",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("myaws version: %s, revision: %s\n", Version, Revision)
+			fmt.Printf("%s\n", version)
 		},
 	}
 


### PR DESCRIPTION
The current docker image doesn't set a version number.
This is caused by setting it by goreleaser.
Let's make it the same way as any other my projects.