### PR TITLE
Build & push docker images on GitHub Actions

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,47 @@
+name: docker
+
+on:
+  push:
+    branches:
+    - master
+    - "docker-build-*"
+    tags:
+    - "v[0-9]+.*"
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  docker:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: docker run
+        if: ${{ github.event_name != 'pull_request' }}
+        run: docker run --rm ${{ github.repository }}:${{ steps.meta.outputs.version }} myaws version


### PR DESCRIPTION
The Docker Hub recently stopped auto builds for free plan. We need to build and push docker images as a part of release process.

Breaking Changes:
The `latest` tag now points at the latest release. Previously the `latest` tag pointed at the master branch, if you want to use the master branch, use the `master` tag instead.