### PR TITLE
Add release target to arm64 architecture

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     env:
       - CGO_ENABLED=0
 archives:


### PR DESCRIPTION
closes #53 

I use M1 MacBook air, and I couldn't install arm64 version of myaws.
So, I added release target to arm64 architecture.

In this settings, linux-arm64 also added release target.
This can ignore, but Raspberry Pi users can user this nice software.
So I don't exclude this.
https://goreleaser.com/customization/build/#builds

