### PR TITLE
Remove docker build on pull request

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,9 +9,6 @@ on:
     - "docker-build-*"
     tags:
     - "v[0-9]+.*"
-  pull_request:
-    branches:
-    - master
 
 jobs:
   docker:


### PR DESCRIPTION
It's not suitable for building on pull request because it's required a credential for docker login.