### PR TITLE
[ssm parameter env] add quote parameter

### DIFF
--- a/cmd/ssm.go
+++ b/cmd/ssm.go
@@ -154,8 +154,10 @@ func newSSMParameterEnvCmd() *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.BoolP("docker-format", "e", false, "Output in docker environment variables format such as -e KEY=VALUE")
+	flags.BoolP("quote", "q", false, "Wrap each value in single quote")
 
 	viper.BindPFlag("ssm.parameter.env.docker-format", flags.Lookup("docker-format")) // nolint: errcheck
+	viper.BindPFlag("ssm.parameter.env.quote", flags.Lookup("quote"))                 // nolint: errcheck
 	return cmd
 }
 
@@ -172,6 +174,7 @@ func runSSMParameterEnvCmd(cmd *cobra.Command, args []string) error {
 	options := myaws.SSMParameterEnvOptions{
 		Name:         args[0],
 		DockerFormat: viper.GetBool("ssm.parameter.env.docker-format"),
+		QuoteValue:   viper.GetBool("ssm.parameter.env.quote"),
 	}
 
 	return client.SSMParameterEnv(options)


### PR DESCRIPTION
Fixes: #58

When values of the AWS SSM parameter store has blanks, `myaws ssm parameter env` does not work as expected.
https://github.com/minamijoyo/myaws/issues/58

So, I added new option `--quote`.
When this parameter is specified, each value wraps in single quote.

## test

```shell
$ myaws ssm parameter put test.env.var '$HOME'
$ myaws ssm parameter put test.str.var 'foo'
$ myaws ssm parameter put test.arr.var 'a b c d'

$ bin/myaws ssm parameter env --help
Print SSM parameters as a list of environment variables

Usage:
  myaws ssm parameter env NAME [flags]

Flags:
  -e, --docker-format   Output in docker environment variables format such as -e KEY=VALUE
  -h, --help            help for env
  -q, --quote           Wrap each value in single quote

Global Flags:
      --config string     config file (default $HOME/.myaws.yml)
      --debug             Enable debug mode
      --humanize          Use Human friendly format for time (default true)
      --profile string    AWS profile (default none and used AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY environment variables.)
      --region string     AWS region (default none and used AWS_DEFAULT_REGION environment variable.
      --timezone string   Time zone, such as UTC, Asia/Tokyo (default "Local")

$ myaws ssm parameter env test
ARR_VAR=a b c d ENV_VAR=$HOME STR_VAR=foo

$ bin/myaws ssm parameter env --quote test
ARR_VAR='a b c d' ENV_VAR='$HOME' STR_VAR='foo'

$ bin/myaws ssm parameter env -q test
ARR_VAR='a b c d' ENV_VAR='$HOME' STR_VAR='foo'
```

