### PR TITLE
[github actions] fix checkout step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout
-    - uses: actions/checkout@v3
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up Go


### PR DESCRIPTION
I found a misplaced hyphen in release.yaml.
This causes error on GitHub Actions.
https://github.com/minamijoyo/myaws/actions/runs/2152792350